### PR TITLE
Fix ec2 setup & few small changes

### DIFF
--- a/doodad/arg_parse.py
+++ b/doodad/arg_parse.py
@@ -22,7 +22,7 @@ def __get_arg_config():
     __ARGS = args
     """
     args_data = os.environ.get(ARGS_DATA, {})
-    use_cloudpickle = os.environ.get(USE_CLOUDPICKLE, True)
+    use_cloudpickle = os.environ.get(USE_CLOUDPICKLE, False)
 
     args = lambda : None # hack - use function as namespace
     args.args_data = args_data
@@ -46,7 +46,7 @@ def get_args(key=None, default=None):
         return data.get(key, default)
     return data
 
-def encode_args(call_args, cloudpickle=True):
+def encode_args(call_args, cloudpickle=False):
     """
     Encode call_args dictionary as a base64 string
     """

--- a/doodad/arg_parse.py
+++ b/doodad/arg_parse.py
@@ -22,7 +22,7 @@ def __get_arg_config():
     __ARGS = args
     """
     args_data = os.environ.get(ARGS_DATA, {})
-    use_cloudpickle = os.environ.get(USE_CLOUDPICKLE, False)
+    use_cloudpickle = os.environ.get(USE_CLOUDPICKLE, True)
 
     args = lambda : None # hack - use function as namespace
     args.args_data = args_data
@@ -46,7 +46,7 @@ def get_args(key=None, default=None):
         return data.get(key, default)
     return data
 
-def encode_args(call_args, cloudpickle=False):
+def encode_args(call_args, cloudpickle=True):
     """
     Encode call_args dictionary as a base64 string
     """

--- a/doodad/launch_tools.py
+++ b/doodad/launch_tools.py
@@ -17,17 +17,18 @@ def launch_shell(
 
 
 def launch_python(
-    target,
-    python_cmd='python',
-    mode=LOCAL,
-    mount_points=None,
-    args=None,
-    env=None,
-    dry=False,
-    fake_display=False,
-    target_mount_dir='target',
-    verbose=False,
-    ):
+        target,
+        python_cmd='python',
+        mode=LOCAL,
+        mount_points=None,
+        args=None,
+        env=None,
+        dry=False,
+        fake_display=False,
+        target_mount_dir='target',
+        verbose=False,
+        use_cloudpickle=False,
+):
     if args is None:
         args = {}
     if mount_points is None:
@@ -45,18 +46,30 @@ def launch_python(
     mount_points = mount_points + [target_mount]
     target_full_path = os.path.join(target_mount.docker_mount_dir(), os.path.basename(target))
 
-    command = make_python_command(target_full_path, args=args, python_cmd=python_cmd, fake_display=fake_display)
+    command = make_python_command(
+        target_full_path,
+        args=args,
+        python_cmd=python_cmd,
+        fake_display=fake_display,
+        use_cloudpickle=use_cloudpickle,
+    )
     mode.launch_command(command, mount_points=mount_points, dry=dry, verbose=verbose)
 
 HEADLESS = 'xvfb-run -a -s "-ac -screen 0 1400x900x24 +extension RANDR"'
-def make_python_command(target, python_cmd='python', args=None, fake_display=False):
+def make_python_command(
+        target,
+        python_cmd='python',
+        args=None,
+        fake_display=False,
+        use_cloudpickle=False,
+):
 
     if fake_display:
         cmd = '{headless} {python_cmd} {target}'.format(headless=HEADLESS, python_cmd=python_cmd, target=target)
     else:
         cmd = '%s %s' % (python_cmd, target)
 
-    args_encoded = encode_args(args)
+    args_encoded = encode_args(args, cloudpickle=use_cloudpickle)
     if args:
         cmd = '%s=%s %s' % (ARGS_DATA, args_encoded, cmd)
     return cmd

--- a/doodad/launch_tools.py
+++ b/doodad/launch_tools.py
@@ -1,6 +1,6 @@
 import os
 
-from .mode import LOCAL
+from .mode import LOCAL, Local
 from .arg_parse import encode_args, ARGS_DATA
 from .mount import MountLocal
 
@@ -38,7 +38,10 @@ def launch_python(
     if not target_mount_dir:
         target_mount_dir = target_dir
     target_mount_dir = os.path.join(target_mount_dir, os.path.basename(target_dir))
-    target_mount = MountLocal(local_dir=target_dir, mount_point=target_mount_dir)
+    if isinstance(mode, Local):
+        target_mount = MountLocal(local_dir=target_dir)
+    else:
+        target_mount = MountLocal(local_dir=target_dir, mount_point=target_mount_dir)
     mount_points = mount_points + [target_mount]
     target_full_path = os.path.join(target_mount.docker_mount_dir(), os.path.basename(target))
 

--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -351,8 +351,8 @@ class EC2SpotDocker(DockerMode):
                 while /bin/true; do
                     aws s3 sync --exclude '*' {include_string} {log_dir} {s3_path}
                     sleep {periodic_sync_interval}
-                done & echo sync
-                initiated""".format(include_string=mount.include_string,
+                done & echo sync initiated
+                """.format(include_string=mount.include_string,
                     log_dir=ec2_local_dir, s3_path=s3_path,
                     periodic_sync_interval=mount.sync_interval))
                 max_sync_interval = max(max_sync_interval, mount.sync_interval)
@@ -427,7 +427,7 @@ class EC2SpotDocker(DockerMode):
 
         if verbose:
             print(full_script)
-        # print(full_script)
+        print(full_script)
         with open("/tmp/full_script", "w") as f:
             f.write(full_script)
 

--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -393,7 +393,7 @@ class EC2SpotDocker(DockerMode):
         sio.write("aws s3 cp /home/ubuntu/user_data.log {s3_dir_path}/stdout.log\n".format(s3_dir_path=s3_dir_path))
         # Wait for last sync/terminal
         if max_sync_interval > 0:
-            sio.write("sleep {}\n".format(max_sync_interval))
+            sio.write("sleep {}\n".format(max_sync_interval + 5))
 
         if self.terminate:
             sio.write("""

--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -25,7 +25,7 @@ class Local(LaunchMode):
         self.env = {}
 
     def launch_command(self, cmd, mount_points=None, dry=False, verbose=False):
-        if dry: 
+        if dry:
             print(cmd); return
 
         commands = CommandBuilder()
@@ -130,7 +130,7 @@ class LocalDocker(DockerMode):
             else:
                 raise NotImplementedError()
 
-        full_cmd = self.get_docker_cmd(cmd, extra_args=mnt_args, pythonpath=py_path, 
+        full_cmd = self.get_docker_cmd(cmd, extra_args=mnt_args, pythonpath=py_path,
                 checkpoint=self.checkpoints)
         if verbose:
             print(full_cmd)
@@ -196,7 +196,7 @@ class SSHDocker(DockerMode):
         with tempfile.NamedTemporaryFile('w+', suffix='.sh') as ntf:
             for cmd in remote_cmds:
                 if verbose:
-                    ntf.write('echo "%s$ %s"\n' % (self.credentials.user_host, cmd)) 
+                    ntf.write('echo "%s$ %s"\n' % (self.credentials.user_host, cmd))
                 ntf.write(cmd+'\n')
             ntf.seek(0)
             ssh_cmd = self.credentials.get_ssh_script_cmd(ntf.name)
@@ -209,7 +209,7 @@ def dedent(s):
     return '\n'.join(lines)
 
 class EC2SpotDocker(DockerMode):
-    def __init__(self, 
+    def __init__(self,
             credentials,
             region='us-west-1',
             instance_type='m1.small',
@@ -274,7 +274,7 @@ class EC2SpotDocker(DockerMode):
             network_interfaces=[], #config.AWS_NETWORK_INTERFACES,
         )
         aws_config = dict(default_config)
-        exp_name = 'run'+self.make_timekey()
+        exp_name = "{}_{}".format(self.s3_log_prefix, self.make_timekey())
         exp_prefix = self.s3_log_prefix
         remote_log_dir = os.path.join(self.aws_s3_path, exp_prefix.replace("_", "-"), exp_name)
         log_dir = "/tmp/expt/local/" + exp_prefix.replace("_", "-") + "/" + exp_name
@@ -315,10 +315,10 @@ class EC2SpotDocker(DockerMode):
                     sio.write("aws s3 cp {s3_path} {remote_tar_name}\n".format(s3_path=s3_path, remote_tar_name=remote_tar_name))
                     sio.write("mkdir -p {local_code_path}\n".format(local_code_path=remote_unpack_name))
                     sio.write("tar -xvf {remote_tar_name} -C {local_code_path}\n".format(
-                        local_code_path=remote_unpack_name, 
+                        local_code_path=remote_unpack_name,
                         remote_tar_name=remote_tar_name))
                     mount_point =  os.path.join('/mounts', mount.mount_point.replace('~/',''))
-                    mnt_args += ' -v %s:%s' % (os.path.join(remote_unpack_name, os.path.basename(mount.local_dir)), mount_point) 
+                    mnt_args += ' -v %s:%s' % (os.path.join(remote_unpack_name, os.path.basename(mount.local_dir)), mount_point)
                     if mount.pythonpath:
                         py_path.append(mount_point)
                 else:
@@ -454,7 +454,7 @@ class EC2SpotDocker(DockerMode):
 
 
 class EC2AutoconfigDocker(EC2SpotDocker):
-    def __init__(self, 
+    def __init__(self,
             region='us-west-1',
             **kwargs
             ):
@@ -473,7 +473,7 @@ class EC2AutoconfigDocker(EC2SpotDocker):
                 iam_instance_profile_name=iam_profile,
                 credentials=credentials,
                 region=region,
-                **kwargs 
+                **kwargs
                 )
 
 

--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -285,7 +285,7 @@ class EC2SpotDocker(DockerMode):
         s3_dir_path = os.path.join(self.aws_s3_path, exp_prefix.replace("_", "-"), exp_name)
         # log_dir = "/tmp/expt/local/" + exp_prefix.replace("_", "-") + "/" + exp_name
         # log_dir = "/tmp/expt/" + exp_prefix.replace("_", "-") + "/" + exp_name
-        log_dir = "/tmp/expt/"
+        # log_dir = "/tmp/expt/"
 
         sio = StringIO()
         sio.write("#!/bin/bash\n")
@@ -333,7 +333,8 @@ class EC2SpotDocker(DockerMode):
                 else:
                     raise ValueError()
             elif isinstance(mount, MountS3):
-                # Make them the same just for convenience
+                # In theory the ec2_local_dir could be some random directory,
+                # but we make them the same just for convenience
                 ec2_local_dir = mount.mount_point
                 s3_path = os.path.join(s3_dir_path, mount.s3_path)
                 if mount.output:
@@ -356,26 +357,26 @@ class EC2SpotDocker(DockerMode):
                     periodic_sync_interval=mount.sync_interval))
                 max_sync_interval = max(max_sync_interval, mount.sync_interval)
                 # Sync on terminate
-                sio.write("""
-                    while /bin/true; do
-                        if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
-                          then
-                            logger "Running shutdown hook."
-                            aws s3 cp --recursive {log_dir} {s3_path}
-                            break
-                          else
-                            # Spot instance not yet marked for termination.
-                            sleep 5
-                        fi
-                    done & echo log sync initiated
-                """.format(log_dir=ec2_local_dir, s3_path=s3_path))
+                # sio.write("""
+                    # while /bin/true; do
+                        # if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
+                          # then
+                            # logger "Running shutdown hook."
+                            # aws s3 cp --recursive {log_dir} {s3_path}
+                            # break
+                          # else
+                            # # Spot instance not yet marked for termination.
+                            # sleep 5
+                        # fi
+                    # done & echo log sync initiated
+                # """.format(log_dir=ec2_local_dir, s3_path=s3_path))
             else:
                 raise NotImplementedError()
 
 
         sio.write("aws ec2 create-tags --resources $EC2_INSTANCE_ID --tags Key=Name,Value={exp_name} --region {aws_region}\n".format(
             exp_name=exp_name, aws_region=self.region))
-        sio.write("mkdir -p {log_dir}\n".format(log_dir=log_dir))
+        # sio.write("mkdir -p {log_dir}\n".format(log_dir=log_dir))
         if self.checkpoint and self.checkpoint.restore:
             raise NotImplementedError()
         else:
@@ -383,6 +384,7 @@ class EC2SpotDocker(DockerMode):
         sio.write(docker_cmd+'\n')
 
         # sio.write("aws s3 cp --recursive {log_dir} {s3_dir_path}\n".format(log_dir=log_dir, s3_dir_path=s3_dir_path))
+        # Sync all output mounts to s3 after runing the docker script
         for (local_output_dir, s3_dir_path) in local_output_dir_and_s3_path:
             sio.write("aws s3 cp --recursive {log_dir} {s3_dir_path}\n".format(
                 log_dir=local_output_dir,
@@ -391,7 +393,7 @@ class EC2SpotDocker(DockerMode):
         sio.write("aws s3 cp /home/ubuntu/user_data.log {s3_dir_path}/stdout.log\n".format(s3_dir_path=s3_dir_path))
         # Wait for last sync/terminal
         if max_sync_interval > 0:
-            sio.write("sleep {}".format(max_sync_interval))
+            sio.write("sleep {}\n".format(max_sync_interval))
 
         if self.terminate:
             sio.write("""

--- a/examples/ec2_launch/ec2_launch_test.py
+++ b/examples/ec2_launch/ec2_launch_test.py
@@ -18,7 +18,7 @@ mode_ssh = dd.mode.SSHDocker(
     credentials=ssh.SSHCredentials(hostname='my.machine.name', username='my_username', identity_file='~/.ssh/id_rsa'),
 )
 
-# or use this! 
+# or use this!
 mode_ec2=None
 #mode_ec2 = dd.mode.EC2AutoconfigDocker(
 #    image='python:3.5',
@@ -30,7 +30,7 @@ mode_ec2=None
 MY_RUN_MODE = mode_docker  # CHANGE THIS
 
 # Set up code and output directories
-OUTPUT_DIR = '/example/outputs'  # this is the directory visible to the target 
+OUTPUT_DIR = '/example/outputs'  # this is the directory visible to the target
 mounts = [
     mount.MountLocal(local_dir=REPO_DIR, pythonpath=True), # Code
     mount.MountLocal(local_dir=os.path.join(EXAMPLES_DIR, 'secretlib'), pythonpath=True), # Code
@@ -39,7 +39,7 @@ mounts = [
 if MY_RUN_MODE == mode_ec2:
     output_mount = mount.MountS3(s3_path='outputs', mount_point=OUTPUT_DIR, output=True)  # use this for ec2
 else:
-    output_mount = mount.MountLocal(local_dir=os.path.join(EXAMPLES_DIR, 'tmp_output'), 
+    output_mount = mount.MountLocal(local_dir=os.path.join(EXAMPLES_DIR, 'tmp_output'),
         mount_point=OUTPUT_DIR, output=True)
 mounts.append(output_mount)
 

--- a/scripts/setup_ec2.py
+++ b/scripts/setup_ec2.py
@@ -25,7 +25,7 @@ if ACCESS_KEY is None:
 ACCESS_SECRET = os.environ.get("AWS_ACCESS_SECRET", None)
 if ACCESS_SECRET is None:
     raise ValueError('Please set the $AWS_ACCESS_KEY environment variable')
-S3_BUCKET_NAME = os.environ.get("$DOODAD_S3_BUCKET", None)
+S3_BUCKET_NAME = os.environ.get("DOODAD_S3_BUCKET", None)
 if S3_BUCKET_NAME is None:
     raise ValueError('Please set the $DOODAD_S3_BUCKET environment variable')
 PREFIX = os.environ.get("RLLAB_PREFIX", "")


### PR DESCRIPTION
Looks like pycharm made a bunch of formatting updates as well (sorry!).
Here are the main fixes/changes:

- scripts/setup_ec2.py Fix typo in setup_ec2 script
- doodad/launch_tools.py: Fix bug in local mode that caused a directory to be mounted to a directory that might not exist. (docker doesn't have this issue since it calls (mkdir -p) on that directory)
- doodad/arg_parse.py: default to use cloudpickle to allow more flexibility in what args can be passed to script
- doodad/mode.py:
   - can set the "experiment name" directory, so that instead of saving things to an s3 folder called `my_exp/run-123123123`, it's called `my-exp/my-exp-123123123123123` (by default) or `my-exp/my-custom-exp-name-123123123` (if you set experiment name). This will also make it so that the ec2 instance name is `my-custom-exp-name-123123123`.
   - remove references to `log_dir` since this is a vestige of rllab.
   - Sync everything to s3 on termination. If things were working before, I think it's either because you happened to name your mount point `/tmp/expt` or because your experiment was long enough so that a periodic sync would save your results before the script terminated. Honestly not 100% sure how things worked before, but I think this code is much more clear.